### PR TITLE
Fix for undefined "type" attribute JS Error

### DIFF
--- a/jquery.ketchup.validations.js
+++ b/jquery.ketchup.validations.js
@@ -1,7 +1,7 @@
 jQuery.ketchup
 
 .validation('required', 'This field is required.', function(form, el, value) {
-  var type = el.attr('type').toLowerCase();
+  var type = el.attr('type') === undefined ? undefined : el.attr('type').toLowerCase();
   
   if(type == 'checkbox' || type == 'radio') {
     return (el.attr('checked') == true);


### PR DESCRIPTION
Just a tiny bugfix to deal with a javascript error I encountered that prevented me from using ketchup for textarea validation. Thanks!
